### PR TITLE
Add permission callback to rest endpoint

### DIFF
--- a/xeno-canto-oembed.php
+++ b/xeno-canto-oembed.php
@@ -25,6 +25,7 @@ add_action(
 			array(
 				'methods'   => WP_REST_Server::READABLE,
 				'callback' => 'xeno_canto_oembed_json',
+				'permission_callback' => current_user_can( 'edit_posts' ),
 				'args'     => array(
 					'url'   => array(
 						'validate_callback' => function( $param ) {


### PR DESCRIPTION
fixes the `Function register_rest_route was called incorrectly. The REST API route definition for xeno-canto-oembed/v1/embed is missing the required permission_callback argument. For REST API routes that are intended to be public, use __return_true as the permission callback. (This message was added in version 5.5.0.)` error message.